### PR TITLE
Replace the MLH Fellowship logo with the MLH Prep logo

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -6,7 +6,7 @@ layout: default
     <div class="container">
         <div class="logo">
             <a href="/">
-                <img src="/assets/img/logo.svg"/>
+                <img src="/assets/img/mlh-prep.png"/>
             </a>
         </div>
         <div class="title">


### PR DESCRIPTION
## Fixing bug: Replacing Fellowship logo with the Prep logo


Fixing bug: Replace the MLH Fellowship logo with the MLH Prep logo.

Solves #7 
